### PR TITLE
Replace deprecated URI.encode with URI.encode_www_form_component

### DIFF
--- a/lib/resque_cleaner/server.rb
+++ b/lib/resque_cleaner/server.rb
@@ -230,7 +230,7 @@ module ResqueCleaner
         f: @from,
         t: @to,
         regex: @regex
-      }.map {|key,value| "#{key}=#{URI.encode(value.to_s)}"}.join("&")
+      }.map {|key,value| "#{key}=#{URI.encode_www_form_component(value.to_s)}"}.join("&")
 
       @list_url = "cleaner_list?#{params}"
       @dump_url = "cleaner_dump?#{params}"

--- a/lib/resque_cleaner/server/views/_stats.erb
+++ b/lib/resque_cleaner/server/views/_stats.erb
@@ -10,7 +10,7 @@
   </tr>
   <% @stats[type.to_sym].each do |field,count| %>
     <tr>
-      <% filter = "#{q}=#{URI.encode(field)}" %>
+      <% filter = "#{q}=#{URI.encode_www_form_component(field)}" %>
       <td><%= field %></td>
       <td class="number">
         <a href="cleaner_list?<%=filter%>"><%= count[:total] %></a>


### PR DESCRIPTION
Similar to https://github.com/ono/resque-cleaner/pull/53

We need to update deprecated code in this repository as part of work to upgrade our application to Ruby 3.

`URI.encode` is obsolete and needs to be replaced.

I replaced it with `encode_www_form_component` to encode the query string instead. 

You can read more about this on the page for the Rubocop lint rule about it https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UriEscapeUnescape