### PR TITLE
Remove use of redis.multi

### DIFF
--- a/lib/resque_cleaner.rb
+++ b/lib/resque_cleaner.rb
@@ -124,18 +124,18 @@ module Resque
               index = @limiter.start_index + i - requeued
 
               value = redis.lindex(:failed, index)
-              redis.multi do
+              redis.multi do |multi|
                 # no change needed to support ActiveJob
                 Job.create(queue||job['queue'], job['payload']['class'], *job['payload']['args'])
 
                 if clear_after_requeue
                   # remove job
                   # TODO: should use ltrim. not sure why i used lrem here...
-                  redis.lrem(:failed, 1, value)
+                  multi.lrem(:failed, 1, value)
                 else
                   # mark retried
                   job['retried_at'] = Time.now.strftime("%Y/%m/%d %H:%M:%S")
-                  redis.lset(:failed, @limiter.start_index+i, Resque.encode(job))
+                  multi.lset(:failed, @limiter.start_index+i, Resque.encode(job))
                 end
               end
 

--- a/lib/resque_cleaner.rb
+++ b/lib/resque_cleaner.rb
@@ -124,19 +124,17 @@ module Resque
               index = @limiter.start_index + i - requeued
 
               value = redis.lindex(:failed, index)
-              redis.multi do |multi|
-                # no change needed to support ActiveJob
-                Job.create(queue||job['queue'], job['payload']['class'], *job['payload']['args'])
+              # no change needed to support ActiveJob
+              Job.create(queue||job['queue'], job['payload']['class'], *job['payload']['args'])
 
-                if clear_after_requeue
-                  # remove job
-                  # TODO: should use ltrim. not sure why i used lrem here...
-                  multi.lrem(:failed, 1, value)
-                else
-                  # mark retried
-                  job['retried_at'] = Time.now.strftime("%Y/%m/%d %H:%M:%S")
-                  multi.lset(:failed, @limiter.start_index+i, Resque.encode(job))
-                end
+              if clear_after_requeue
+                # remove job
+                # TODO: should use ltrim. not sure why i used lrem here...
+                redis.lrem(:failed, 1, value)
+              else
+                # mark retried
+                job['retried_at'] = Time.now.strftime("%Y/%m/%d %H:%M:%S")
+                redis.lset(:failed, @limiter.start_index+i, Resque.encode(job))
               end
 
               requeued += 1


### PR DESCRIPTION
redis 4.6 deprecated the use of `redis.multi` without explicitly naming the `multi` argument when performing redis operations

changing to
```ruby
redis.multi do |multi|
  Job.create
  multi.whatever
end
```
isn't enough, because `Job.create` itself calls into redis. The only "real" way to resolve this that I can tell is to remove the multi block altogether. 